### PR TITLE
Style: 공통 컴포넌트 작업 완료(작고 둥글거나 각진 버튼, 큰 버튼, 모달) #10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.2.1",
         "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
@@ -4068,6 +4069,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.2.1",
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {

--- a/src/components/buttons/BigButton.tsx
+++ b/src/components/buttons/BigButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { FaPlus } from "react-icons/fa6";
+
+interface BigButtonProps {
+  handleClick: () => void;
+  buttonText: string;
+  disabled?: boolean;
+}
+
+// props로 버튼 텍스트만 피그마에 있는 그대로 넘겨주시면
+// 스타일(아이콘 포함)은 텍스트별로 자동으로 맞춰집니다.
+const BigButton: React.FC<BigButtonProps> = ({ handleClick, buttonText, disabled }) => {
+  return (
+    <button
+      className={`${buttonText === "첫 레시피 등록하기" ? "w-[60%]" : "w-[90%]"}  h-[48px] rounded-[6px] text-[16px] text-center ${buttonText === "재료 더 보기" ? "text-midnightGray bg-iceBlue" : "text-redPink bg-softPink"} `}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      {buttonText === "첫 레시피 등록하기" ? (
+        <div className="flex items-center justify-center gap-[20px]">
+          <FaPlus />
+          <span>{buttonText}</span>
+        </div>
+      ) : (
+        <span>{buttonText}</span>
+      )}
+    </button>
+  );
+};
+
+export default BigButton;

--- a/src/components/buttons/RectangularSmallButton.tsx
+++ b/src/components/buttons/RectangularSmallButton.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { FaPlus } from "react-icons/fa6";
+
+interface RectangularSmallButtonProps {
+  handleClick: () => void;
+  buttonText: string;
+  disabled?: boolean;
+}
+
+// props로 버튼 텍스트만 피그마에 있는 그대로 넘겨주시면
+// 스타일(아이콘 포함)은 텍스트별로 자동으로 맞춰집니다.
+const RectangularSmallButton: React.FC<RectangularSmallButtonProps> = ({
+  handleClick,
+  buttonText,
+  disabled,
+}) => {
+  return (
+    <button
+      className={`font-semibold text-sm border px-[10px] py-[6px] min-h-[32px] min-w-[79px] rounded-[6px] bg-[#FFFFFF] text-midnightGray border-cloudGray ${buttonText === "완료" ? "bg-gray-100" : buttonText === "재료 추가" && "text-redPink border-redPink"}`}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      {buttonText === "재료 추가" ? (
+        <div className="flex items-center justify-center gap-[5px]">
+          <FaPlus />
+          <span>{buttonText}</span>
+        </div>
+      ) : (
+        <span>{buttonText}</span>
+      )}
+    </button>
+  );
+};
+
+export default RectangularSmallButton;

--- a/src/components/buttons/RoundedSmallButton.tsx
+++ b/src/components/buttons/RoundedSmallButton.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface RoundedSmallButtonProps {
+  handleClick: () => void;
+  buttonText: string;
+  disabled?: boolean;
+  isClicked?: boolean;
+}
+
+// 다음 버튼일때는 disabled만 넘겨주면 되고
+// 추가, 취소 버튼일때는 isClicked만 넘겨주면 됩니다.
+// 필요하면 둘 다 넣으셔도 되구요.
+const RoundedSmallButton: React.FC<RoundedSmallButtonProps> = ({
+  handleClick,
+  buttonText,
+  disabled,
+  isClicked,
+}) => {
+  return (
+    <button
+      className={`px-3 border rounded-[20px] ${disabled ? "bg-[#93939388] text-[#FFFFFF]" : isClicked ? "bg-blushPink text-redPink" : "bg-softPink text-redPink"} text-[12px] w-16 h-6`}
+      disabled={disabled}
+      onClick={handleClick}
+    >
+      {buttonText}
+    </button>
+  );
+};
+
+export default RoundedSmallButton;

--- a/src/components/modal/ProceedModal.tsx
+++ b/src/components/modal/ProceedModal.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface ModalProps {
+  proceedQuestionText: string;
+  handleRightClick: () => void;
+  handleLeftClick: () => void;
+}
+
+const ProceedModal: React.FC<ModalProps> = ({
+  proceedQuestionText,
+  handleLeftClick,
+  handleRightClick,
+}) => {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div
+        className="bg-white p-8 shadow-lg rounded-[4px] w-72 border border-[#C2C2C2]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-6 text-md text-center">
+          <span>{proceedQuestionText}</span>
+        </div>
+
+        <div className="flex justify-center gap-7">
+          <button
+            className="px-4 py-2 bg-gray-200 rounded-[6px] hover:bg-gray-300 w-20 text-md"
+            onClick={handleLeftClick}
+          >
+            예
+          </button>
+          <button
+            className="px-4 py-2 bg-gray-200 rounded-[6px] hover:bg-gray-300 w-20 text-md"
+            onClick={handleRightClick}
+          >
+            아니요
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProceedModal;


### PR DESCRIPTION
#10 
1. modal 컴포넌트에서는 모달의 질문 text, 예를 눌렀을때 실행하는 함수(handleLeftClick), 아니오를 눌렀을때 실행하는 함수(handleRightClick)를 props로 받습니다.

2. BigButton 컴포넌트에서는 버튼에 들어가는 text, 버튼을 클릭할때 실행하는 함수(handleClick), disabled(optional)을 props로 받고, disabled(optional)은 버튼의 활성화 여부를 나타냅니다. true는 비활성화 상태, false는 활성화 상태
- props로 text만 피그마에 있는 그대로 넘겨주시면 스타일(아이콘 포함)은 텍스트별로 자동으로 맞춰집니다.

3. RoundedSmallButton 컴포넌트는 작은 버튼 중에 둥글둥글한 모양의 버튼이고 위와 마찬가지로 text, handleClick, disabled(optional), isClicked(optional)을 props로 받습니다.
- 다음 버튼일때는 disabled만 넘겨주면 되고, 추가, 취소 버튼일때는 isClicked만 넘겨주면 됩니다.
- 필요하면 둘 다 넣으셔도 되구요.

4. RectangularSmallButton 컴포넌트는 작은 버튼 중에 둥글둥글한 모양의 버튼을 제외한 조금 각진 모양의 버튼이고 위와 마찬가지로 text, handleClick, disabled(optional)을 props로 받음
- props로 text만 피그마에 있는 그대로 넘겨주시면 스타일(아이콘 포함)은 텍스트별로 자동으로 맞춰집니다.
